### PR TITLE
Update default platforms in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
             platforms:
                 description: Platforms to build for
                 type: choice
-                default: linux/amd64,linux/arm64
+                default: linux/amd64
                 options:
                 - linux/amd64,linux/arm64
                 - linux/amd64
@@ -44,3 +44,4 @@ jobs:
                 push_latest: ${{ inputs.push_latest}}
                 registry_token: ${{ github.token }}
                 rebuild: ${{ inputs.rebuild }}
+                platforms: ${{ inputs.platforms }}


### PR DESCRIPTION
Also passing the platforms variable to the downstream build@v1 action